### PR TITLE
Don't return a mention that is a terminator

### DIFF
--- a/mention.go
+++ b/mention.go
@@ -67,10 +67,6 @@ func splitTag(char rune, terminator ...rune) bufio.SplitFunc {
 					// we stop when we encounter another char instance
 					// this can be a case like @gernest@gernest
 					if xFirst == char {
-						// if we only have one character (which is '@'), return nothing
-						if n-begin == 1 {
-							return 0, nil, nil
-						}
 						return n - width, data[begin:n], nil
 					}
 
@@ -79,7 +75,7 @@ func splitTag(char rune, terminator ...rune) bufio.SplitFunc {
 							// If when reaching our terminator, its the only
 							// character in the data, ignore the mention. (ie "@,")
 							if n-begin == 1 {
-								return 0, nil, nil
+								return n + width, data[begin : n-1], nil
 							}
 							return n + width, data[begin:n], nil
 						}
@@ -90,7 +86,7 @@ func splitTag(char rune, terminator ...rune) bufio.SplitFunc {
 						// make sure our result isn't just a single terminator (ie "@@")
 						for _, term := range terminator {
 							if n-begin == 1 && rune(data[begin:n][0]) == term {
-								return 0, nil, nil
+								return n + width, data[begin : n-1], nil
 							}
 						}
 						return n + width, data[begin:n], nil

--- a/mention.go
+++ b/mention.go
@@ -67,17 +67,32 @@ func splitTag(char rune, terminator ...rune) bufio.SplitFunc {
 					// we stop when we encounter another char instance
 					// this can be a case like @gernest@gernest
 					if xFirst == char {
+						// if we only have one character (which is '@'), return nothing
+						if n-begin == 1 {
+							return 0, nil, nil
+						}
 						return n - width, data[begin:n], nil
 					}
 
 					for _, term := range terminator {
 						if xFirst == term {
+							// If when reaching our terminator, its the only
+							// character in the data, ignore the mention. (ie "@,")
+							if n-begin == 1 {
+								return 0, nil, nil
+							}
 							return n + width, data[begin:n], nil
 						}
 					}
 
 					// the end of our tag
 					if unicode.IsSpace(xFirst) {
+						// make sure our result isn't just a single terminator (ie "@@")
+						for _, term := range terminator {
+							if n-begin == 1 && rune(data[begin:n][0]) == term {
+								return 0, nil, nil
+							}
+						}
 						return n + width, data[begin:n], nil
 					}
 				}

--- a/mention_test.go
+++ b/mention_test.go
@@ -20,9 +20,10 @@ func TestGetTag(t *testing.T) {
 		{" @gernest @mwanza @tanzania", []string{"gernest", "mwanza", "tanzania"}},
 		{" @gernest,@mwanza/Tanzania ", []string{"gernest", "mwanza"}},
 		{"how does it feel to be rejected? @ it is @loner tt ggg sjdsj dj @linker ", []string{"loner", "linker"}},
+		{"This @gernest is @@ @ @,, @,", []string{"gernest"}},
 	}
 
-	terminators := []rune{',', '/'}
+	terminators := []rune{',', '/', '@'}
 	for _, v := range sample {
 		tag := GetTags('@', strings.NewReader(v.src), terminators...)
 		if !reflect.DeepEqual(v.tag, tag) {

--- a/mention_test.go
+++ b/mention_test.go
@@ -20,7 +20,7 @@ func TestGetTag(t *testing.T) {
 		{" @gernest @mwanza @tanzania", []string{"gernest", "mwanza", "tanzania"}},
 		{" @gernest,@mwanza/Tanzania ", []string{"gernest", "mwanza"}},
 		{"how does it feel to be rejected? @ it is @loner tt ggg sjdsj dj @linker ", []string{"loner", "linker"}},
-		{"This @gernest is @@ @ @,, @,", []string{"gernest"}},
+		{"This @gernest is @@ @ @,, @, @mwanza", []string{"gernest", "mwanza"}},
 	}
 
 	terminators := []rune{',', '/', '@'}


### PR DESCRIPTION
Fixes https://github.com/gernest/mention/issues/5

This is intended that if we have a terminator that is `,` or `@`, that we don't return a mention that is just that terminator