### PR TITLE
Always separate on spaces and unprintable characters

### DIFF
--- a/mention.go
+++ b/mention.go
@@ -3,6 +3,7 @@ package mention
 
 import (
 	"strings"
+	"unicode"
 )
 
 type Tag struct {
@@ -68,7 +69,7 @@ func isTerminator(r rune, terminator ...rune) bool {
 			return true
 		}
 	}
-	return false
+	return unicode.IsSpace(r) || !unicode.IsPrint(r)
 }
 
 // Ensures the given slice of strings are unique and that none are empty

--- a/mention_test.go
+++ b/mention_test.go
@@ -110,8 +110,24 @@ func (s *MentionSuite) TestGetTags(c *C) {
 			"hello@world",
 			nil,
 		},
+		{
+			"@hello\u2000world", // en space
+			[]Tag{{'@', "hello", 0}},
+		},
+		{
+			"@hello\u200dworld", // zero width joiner (unprintable)
+			[]Tag{{'@', "hello", 0}},
+		},
+		{
+			"@hello\x1eworld", // control character
+			[]Tag{{'@', "hello", 0}},
+		},
+		{
+			"Hello @العَرَبِيَّة there",
+			[]Tag{{'@', "العَرَبِيَّة", 6}},
+		},
 	}
-	terms := []rune(",/. ")
+	terms := []rune(",/.")
 
 	for _, v := range sample {
 		c.Assert(GetTags('@', v.src, terms...), DeepEquals, v.tags, Commentf("Failed: %+v", v))
@@ -119,4 +135,12 @@ func (s *MentionSuite) TestGetTags(c *C) {
 
 	// use default terminators
 	c.Assert(GetTags('@', "hello @test"), DeepEquals, []Tag{{'@', "test", 6}})
+}
+
+func BenchmarkGetTags(b *testing.B) {
+	terms := []rune(",/. ")
+	src := "This @gernest is @hello\u2000world @hello\u200d"
+	for i := 0; i < b.N; i++ {
+		GetTags('@', src, terms...)
+	}
 }


### PR DESCRIPTION
Some code is sending our backend mentions with a zero-width joiner for
whatever reason, for example:

    @example\u200d skldjg

The mention that would would get picked up is `@example\u200d`, instead
of the expected `@example`.

This patch always treats spaces and unprintable characters as
a terminator. I'm not sure if it ever makes sense to use a space inside
a mention?

Alternatively, I could add a callback function, or something?
Maintaining a list of all space/unprintable characters doesn't strike me
as a good idea, and the `unicode.Is*()` functions contain some
performance optimisations for the common (non-multibyte) use cases.

The downside is some performance loss:

master:

    BenchmarkGetTags-4       2000000               950 ns/op

this:

    BenchmarkGetTags-4       1000000              1312 ns/op